### PR TITLE
Fix non-deterministic link source-target ordering

### DIFF
--- a/orca/topology/linker.py
+++ b/orca/topology/linker.py
@@ -102,36 +102,27 @@ class Linker(abc.ABC):
         return self.source_spec.kind
 
     def _get_new_links(self, node):
-        linked_nodes = self._get_linked_nodes(node)
-        links = []
-        for linked_node in linked_nodes:
-            link = graph.Graph.create_link({}, node, linked_node)
-            links.append(link)
-        return links
-
-    def _get_linked_nodes(self, node):
         if node.kind == self.source_spec.kind:
-            return self._get_linked_from_source(node)
-        else:
-            return self._get_linked_from_target(node)
+            return self._get_links_from_source(node)
+        return self._get_links_from_target(node)
 
-    def _get_linked_from_source(self, source_node):
-        linked_nodes = []
+    def _get_links_from_source(self, source_node):
+        links = []
         target_nodes = self._graph.get_nodes(
             origin=self.target_spec.origin, kind=self.target_spec.kind)
         for target_node in target_nodes:
             if self._matcher.are_linked(source_node, target_node):
-                linked_nodes.append(target_node)
-        return linked_nodes
+                links.append(graph.Graph.create_link({}, source_node, target_node))
+        return links
 
-    def _get_linked_from_target(self, target_node):
-        linked_nodes = []
+    def _get_links_from_target(self, target_node):
+        links = []
         source_nodes = self._graph.get_nodes(
             origin=self.source_spec.origin, kind=self.source_spec.kind)
         for source_node in source_nodes:
             if self._matcher.are_linked(source_node, target_node):
-                linked_nodes.append(source_node)
-        return linked_nodes
+                links.append(graph.Graph.create_link({}, source_node, target_node))
+        return links
 
     def _build_link_lookup(self, links):
         return {link.id: link for link in links}

--- a/orca/topology/linker.py
+++ b/orca/topology/linker.py
@@ -93,16 +93,12 @@ class Linker(abc.ABC):
             self._graph.add_link(new_links[link_id])
 
     def _get_current_links(self, node):
-        target_kind = self._get_target_kind(node)
-        return self._graph.get_node_links(node, kind=target_kind)
-
-    def _get_target_kind(self, node):
-        if node.kind == self.source_spec.kind:
-            return self.target_spec.kind
-        return self.source_spec.kind
+        target_spec = self._get_target_spec(node)
+        return self._graph.get_node_links(
+            node, origin=target_spec.origin, kind=target_spec.kind)
 
     def _get_new_links(self, node):
-        if node.kind == self.source_spec.kind:
+        if self._is_source(node):
             return self._get_links_from_source(node)
         return self._get_links_from_target(node)
 
@@ -123,6 +119,17 @@ class Linker(abc.ABC):
             if self._matcher.are_linked(source_node, target_node):
                 links.append(graph.Graph.create_link({}, source_node, target_node))
         return links
+
+    def _get_target_spec(self, node):
+        if self._is_source(node):
+            return self.target_spec
+        return self.source_spec
+
+    def _is_source(self, node):
+        if node.origin == self.source_spec.origin and \
+           node.kind == self.source_spec.kind:
+            return True
+        return False
 
     def _build_link_lookup(self, links):
         return {link.id: link for link in links}


### PR DESCRIPTION
Fixes non-deterministic link IDs due to lack of link source-target node ordering:
```
current links: {'d2f6d901-1eb6-50fe-890e-2a337a6bd0c5': <Link id=d2f6d901-1eb6-50fe-890e-2a337a6bd0c5 properties={} source=85b695c0-9ed6-4ea9-bf12-ad06488d86c1 target=9d45f2c4-89ad-4993-b162-a7a0c398d76b>} 

new links: {'15f297c8-1873-5ab1-b5b9-e430279aeaf8': <Link id=15f297c8-1873-5ab1-b5b9-e430279aeaf8 properties={} source=85b695c0-9ed6-4ea9-bf12-ad06488d86c1 target=9d45f2c4-89ad-4993-b162-a7a0c398d76b>}
```