### PR TITLE
Add extended graph node payload

### DIFF
--- a/orca/api/resources/v1/graph.py
+++ b/orca/api/resources/v1/graph.py
@@ -14,10 +14,15 @@
 
 from flask_restx import Model, Namespace, Resource, fields, marshal
 
+
 node_fields = Model('Graph Node', {
     'id': fields.String,
     'origin': fields.String,
-    'kind': fields.String
+    'kind': fields.String,
+    'properties': {
+        'name': fields.String(attribute='properties.name'),
+        'namespace': fields.String(attribute='properties.namespace', default="n/a")
+    }
 })
 
 link_fields = Model('Graph Link', {


### PR DESCRIPTION
Adds `name` and `namespace` properties to graph node payload.

Closes #96.